### PR TITLE
Move to DNS forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ Turn on developer mode
 Click on Load unpacked
 Select the project folder
 Open the extension, you'll be promted for 3 inputs
-  - Godaddy API Key: You can generate one from [here](https://urlforwarding.api.godaddy.com/docs#/api-key/generateApiKey) or if you want to work with `meet.sudipmondal.co.in`, you can obtain it from me.
+  - Godaddy API Key: You can generate one from [here](https://developer.godaddy.com/doc/endpoint/domains#/v1/recordAdd) or if you want to work with `meet.sudipmondal.co.in`, you can obtain it from me.
     - If you work with your own API Key, update the domain name in `background.js` line no 2
     - API key is just a one time thing, you don't need to put it again
   - Authuser, for multiple google users(0 based index) in your browsers, you can choose which user will be the owner of the meet
-  - Meeting name: It's the suffix of the url. For example if you choose `john-doe` as meeting url, the meet will be `meet.sudipmondal.co.in/john-doe`.
+  - Meeting name: It's the suffix of the url. For example if you choose `john-doe` as meeting url, the meet will be `john-doe.meet.sudipmondal.co.in`.
 
 ## Accessing API key from maintainers
 - Create an issue or choose an existing issue, get it assigned to you.
 - Send an email to sudmondal2002@gmail.com mentioning your issue number that you need the API key.
-

--- a/background.js
+++ b/background.js
@@ -36,13 +36,19 @@ function createGoogleMeet(meetingName, authuser) {
 function shortenUrl(request, url){
     const original_meet_url = url.split('?')[0]
     const meeting_name = url.split('meeting_name=')[1]
-    const short_api_url = `https://urlforwarding.api.godaddy.com/v1/?apikey=${API_KEY}&domain=${domain}&url=${original_meet_url}`
-    const body = new FormData()
-    body.append('code', meeting_name)
+    const short_api_url = `https://api.godaddy.com/v1/domains/${domain}/records/CNAME/${meeting_name}`
+    const body = JSON.stringify({
+        "data": original_meet_url,
+        "ttl": 600
+    })
     console.log(short_api_url)
 
     fetch(short_api_url, {
         method: "PUT",
+        headers: {
+            "Authorization": `sso-key ${API_KEY}`,
+            "Content-Type": "application/json"
+        },
         body: body
     }).then(res=>res.json())
         .then((short_url) =>{

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "permissions": ["identity", "identity.email", "scripting", "clipboardWrite"],
   "host_permissions": [
     "https://meet.google.com/*",
-    "*://urlforwarding.api.godaddy.com/*"
+    "*://api.godaddy.com/*"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
Closes #1

Update the extension to use DNS forwarding for meeting URLs.

* **background.js**
  - Update the `shortenUrl` function to use the GoDaddy DNS forwarding API endpoint.
  - Update the `short_api_url` variable to construct the API URL using the GoDaddy DNS forwarding API.
  - Update the `fetch` method to use the GoDaddy DNS forwarding API endpoint.

* **manifest.json**
  - Update the `host_permissions` to include the GoDaddy DNS forwarding API endpoint.

* **README.md**
  - Update the instructions to reference the use of the GoDaddy DNS forwarding API.
  - Update the instructions to include the new API key generation link for GoDaddy DNS forwarding API.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sudip-mondal-2002/meetpro/issues/1?shareId=1a35a10b-d7ed-4f06-8d20-be48ac1a02ee).